### PR TITLE
add optional bits_to_null field to badpixfromfits

### DIFF
--- a/montara/badpixfromfits.py
+++ b/montara/badpixfromfits.py
@@ -8,7 +8,17 @@ class BadPixFromFitsBuilder(ExtraOutputBuilder):
     def processImage(self, index, obj_nums, config, base, logger):
         mask_file = ParseValue(config, 'mask_file', base, str)[0]
         mask_hdu = ParseValue(config, 'mask_hdu', base, int)[0]
+
         mask_image = galsim.fits.read(mask_file, hdu=mask_hdu)
+
+        if 'bits_to_null' in config:
+            b2nlist = ParseValue(config, 'bits_to_null', base, list)[0]
+            b2n = 0
+            for tb2n in b2nlist:
+                b2n |= tb2n
+
+            mask_image.array[:, :] &= ~b2n
+
         self.data[index] = mask_image
 
 


### PR DESCRIPTION
bits_to_null is a list of bits to null
These are nulled in the mask image before setting
in the self.data